### PR TITLE
Fix parsing VDF files with duplicate keys

### DIFF
--- a/lexer_test.go
+++ b/lexer_test.go
@@ -1,41 +1,39 @@
-package vdf_test
+package vdf
 
 import (
 	"strings"
 	"testing"
-
-	"github.com/andygrunwald/vdf"
 )
 
 // Ensure the scanner can scan tokens correctly.
 func TestScanner_Scan(t *testing.T) {
 	var tests = []struct {
 		s   string
-		tok vdf.Token
+		tok Token
 		lit string
 	}{
 		// Special tokens (EOF, ILLEGAL, WS)
-		{s: ``, tok: vdf.EOF},
-		{s: `#`, tok: vdf.Illegal, lit: `#`},
-		{s: ` `, tok: vdf.WS, lit: " "},
-		{s: "\t", tok: vdf.WS, lit: "\t"},
-		{s: "\n", tok: vdf.WS, lit: "\n"},
-		{s: "\r", tok: vdf.WS, lit: "\r"},
+		{s: ``, tok: EOF},
+		{s: `#`, tok: Illegal, lit: `#`},
+		{s: ` `, tok: WS, lit: " "},
+		{s: "\t", tok: WS, lit: "\t"},
+		{s: "\n", tok: WS, lit: "\n"},
+		{s: "\r", tok: WS, lit: "\r"},
 
 		// Misc characters
-		{s: `{`, tok: vdf.CurlyBraceOpen, lit: "{"},
-		{s: `}`, tok: vdf.CurlyBraceClose, lit: "}"},
-		{s: `"`, tok: vdf.QuotationMark, lit: "\""},
-		{s: `\`, tok: vdf.EscapeSequence, lit: "\\"},
-		{s: "//", tok: vdf.CommentDoubleSlash, lit: "//"},
+		{s: `{`, tok: CurlyBraceOpen, lit: "{"},
+		{s: `}`, tok: CurlyBraceClose, lit: "}"},
+		{s: `"`, tok: QuotationMark, lit: "\""},
+		{s: `\`, tok: EscapeSequence, lit: "\\"},
+		{s: "//", tok: CommentDoubleSlash, lit: "//"},
 
 		// Identifiers
-		{s: `foo`, tok: vdf.Ident, lit: `foo`},
-		{s: `Zx12_3U_-`, tok: vdf.Ident, lit: `Zx12_3U_`},
+		{s: `foo`, tok: Ident, lit: `foo`},
+		{s: `Zx12_3U_-`, tok: Ident, lit: `Zx12_3U_`},
 	}
 
 	for i, tt := range tests {
-		s := vdf.NewScanner(strings.NewReader(tt.s))
+		s := NewScanner(strings.NewReader(tt.s))
 		tok, lit := s.Scan(false)
 		if tt.tok != tok {
 			t.Errorf("%d. %q token mismatch: exp=%q got=%q <%q>", i, tt.s, tt.tok, tok, lit)

--- a/parser.go
+++ b/parser.go
@@ -147,7 +147,7 @@ func (p *Parser) parseMap() map[string]interface{} {
 			m[key] = lit
 		case CurlyBraceOpen:
 			p.unscan()
-			m[key] = p.parseMap()
+			mergeMap(m, p.parseMap(), key)
 		case CurlyBraceClose:
 			return m
 		default:
@@ -194,4 +194,17 @@ func (p *Parser) scanIdentSurroundedQuotationMark() (Token, string) {
 	}
 
 	return Ident, buf.String()
+}
+
+// VDF files can contain duplicates of keys, when this occurs we need to merge the existing map and the returned map
+func mergeMap(m, r map[string]interface{}, key string) map[string]interface{} {
+	if _, ok := m[key]; !ok {
+		m[key] = r
+	} else {
+		for k, v := range r {
+			m[key].(map[string]interface{})[k] = v
+		}
+	}
+
+	return m
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -1,11 +1,9 @@
-package vdf_test
+package vdf
 
 import (
 	"reflect"
 	"strings"
 	"testing"
-
-	"github.com/andygrunwald/vdf"
 )
 
 // Ensure the parser can parse strings into Statement ASTs.
@@ -171,10 +169,31 @@ func TestParser_ParseStatement(t *testing.T) {
 				},
 			},
 		},
+		{
+			s: `"Root"
+{
+ "map"
+ {
+   "attr1" "hello"
+ }
+ "map"
+ {
+   "attr2" "world"
+ }
+}`,
+			m: map[string]interface{}{
+				"Root": map[string]interface{}{
+					"map": map[string]interface{}{
+						"attr1": "hello",
+						"attr2": "world",
+					},
+				},
+			},
+		},
 	}
 
 	for i, tt := range tests {
-		m, err := vdf.NewParser(strings.NewReader(tt.s)).Parse()
+		m, err := NewParser(strings.NewReader(tt.s)).Parse()
 		if !reflect.DeepEqual(tt.err, (err)) {
 			t.Errorf("%d. %q: error mismatch:\n  exp=%s\n  got=%s\n\n", i, tt.s, tt.err, err)
 		} else if tt.err == nil && !reflect.DeepEqual(tt.m, m) {


### PR DESCRIPTION
An example of a VDF with duplicate keys would be the items_game file from CSGO, it has multiple "items" keys. Here is a copy of it: https://raw.githubusercontent.com/SteamDatabase/GameTracking-CSGO/master/csgo/scripts/items/items_game.txt

This also includes a fix for the tests to be contained within the package it is testing.