### PR TITLE
Allow newlines between K-V pairs

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,7 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
-github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/parser.go
+++ b/parser.go
@@ -48,7 +48,7 @@ func (p *Parser) scanIgnoreWSAndComments() (Token, string) {
 	tok, lit := p.scan(false)
 
 	// If we have a whitespace, just continue scanning until the next token appears
-	if tok == WS {
+	for tok == WS || tok == EOL {
 		tok, lit = p.scan(false)
 	}
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -36,6 +36,7 @@ func TestParser_ParseStatement(t *testing.T) {
 			s: `"Root"
 {
  "attr1"       "hey-ho"
+
  "attr2"       "ho-hey"
  "map1"
  {

--- a/testdata/ok.vdf
+++ b/testdata/ok.vdf
@@ -1,5 +1,6 @@
 "SaveFile"
 {
 	"team1"		"ciccio"
+
 	"team2"		"pasticcio"
 }


### PR DESCRIPTION
example of this being valid: https://raw.githubusercontent.com/SteamDatabase/GameTracking-CSGO/master/csgo/resource/csgo_english.txt

also fixes some compilation error I got due to `go.sum` being off apparently

thanks a lot for this lib btw :heart: 